### PR TITLE
Try to fix issue #3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
         "psr-4": {
             "Ancarda\\File\\": "src"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ancarda\\File\\Test\\": "tests"
+        }
     }
 }

--- a/src/Detector.php
+++ b/src/Detector.php
@@ -89,6 +89,10 @@ final class Detector
     {
         $out = [];
         for ($i = 0; $i < $len; $i++) {
+            if (empty($bstr[$i])) {
+                throw new UnreadableStreamException('The stream in offset ' . $i . ' cannot be readable.');
+            }
+
             $out[] = ord($bstr[$i]);
         }
         return $out;

--- a/src/Detector.php
+++ b/src/Detector.php
@@ -90,7 +90,7 @@ final class Detector
         $out = [];
         for ($i = 0; $i < $len; $i++) {
             if (empty($bstr[$i])) {
-                throw new UnreadableStreamException('The stream in offset ' . $i . ' cannot be readable.');
+                throw new UnreadableStreamException('The stream in offset ' . $i . ' is not readable.');
             }
 
             $out[] = ord($bstr[$i]);

--- a/src/UnreadableStreamException.php
+++ b/src/UnreadableStreamException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Ancarda\File;
 
-use Exception;
+use InvalidArgumentException;
 
-class UnreadableStreamException extends Exception
+class UnreadableStreamException extends InvalidArgumentException
 {
 }

--- a/src/UnreadableStreamException.php
+++ b/src/UnreadableStreamException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ancarda\File;
+
+use Exception;
+
+class UnreadableStreamException extends Exception
+{
+}

--- a/tests/MimeTest.php
+++ b/tests/MimeTest.php
@@ -78,7 +78,7 @@ final class MimeTest extends TestCase
     {
         $stream = fopen('php://memory', 'w');
         fwrite($stream, random_bytes(100));
-        fread($stream, 100);
+        fread($stream, 1);
         return $stream;
     }
 }

--- a/tests/MimeTest.php
+++ b/tests/MimeTest.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Test;
+namespace Ancarda\File\Test;
 
-use \Ancarda\File\Detector;
-use \PHPUnit\Framework\TestCase;
+use Ancarda\File\Detector;
+use Ancarda\File\UnreadableStreamException;
+use PHPUnit\Framework\TestCase;
 
 final class MimeTest extends TestCase
 {
@@ -13,7 +14,7 @@ final class MimeTest extends TestCase
 
     public function setUp()
     {
-        $this->detector = new \Ancarda\File\Detector;
+        $this->detector = new Detector;
     }
 
     public function testText()
@@ -22,6 +23,13 @@ final class MimeTest extends TestCase
         $mime = $this->detector->determineMimeType($stream);
         $this->assertEquals('text/plain; charset=utf-8', $mime);
         fclose($stream);
+    }
+
+    public function testTextThrowsUnreadableStreamException()
+    {
+        $stream = $this->invalidStreamFromString('this is some text');
+        $this->expectException(UnreadableStreamException::class);
+        $this->detector->determineMimeType($stream);
     }
 
     public function testJpeg()
@@ -63,6 +71,14 @@ final class MimeTest extends TestCase
         $stream = fopen('php://memory', 'rw');
         fwrite($stream, $s);
         rewind($stream);
+        return $stream;
+    }
+
+    private function invalidStreamFromString(string $s)
+    {
+        $stream = fopen('php://memory', 'w');
+        fwrite($stream, random_bytes(100));
+        fread($stream, 100);
         return $stream;
     }
 }


### PR DESCRIPTION
# Changed log
- It's related to issue #3.
- In the second scenario, ```E_WARNING``` is not possible to be triggered because it will throw the ```InvalidArgumentException``` because the variable ```$s``` is not the resource type.