### PR TITLE
Use SplFileObject instead of streams

### DIFF
--- a/src/Detector.php
+++ b/src/Detector.php
@@ -79,11 +79,12 @@ final class Detector
         $position = $file->ftell();
         $move = $file->fseek($start, \SEEK_SET);
         $read = $file->fread($length);
-        if ($position === false || $move === -1 || $read === false) {
-            throw new \Exception('Could not seek through and read from the file.');
+        // Reading failed, or the reading start position was uncertain.
+        if ($read === false || $move === -1 && $position !== $start) {
+            throw new \Exception('Could not read specified bytes from the file.');
         }
-        $back = $file->fseek($position, \SEEK_SET);
-        if ($back === -1) {
+        // The original position is unknown or the position could not be set to it.
+        if ($position === false || $file->fseek($position, \SEEK_SET) === -1) {
             throw new \Exception('Could not reset the cursor.');
         }
         return $read;

--- a/tests/MimeTest.php
+++ b/tests/MimeTest.php
@@ -18,10 +18,9 @@ final class MimeTest extends TestCase
 
     public function testText()
     {
-        $stream = $this->streamFromString('this is some text');
-        $mime = $this->detector->determineMimeType($stream);
+        $file = $this->fileFromString('this is some text');
+        $mime = $this->detector->determineMimeType($file);
         $this->assertEquals('text/plain; charset=utf-8', $mime);
-        fclose($stream);
     }
 
     public function testJpeg()
@@ -52,17 +51,16 @@ final class MimeTest extends TestCase
 
     private function assertFileHasMimeType(string $path, string $filetype)
     {
-        $stream = fopen(__DIR__ . '/files/' . $path, 'r');
-        $mime = $this->detector->determineMimeType($stream);
+        $file = new \SplFileObject(__DIR__ . '/files/' . $path, 'r');
+        $mime = $this->detector->determineMimeType($file);
         $this->assertEquals($filetype, $mime);
-        fclose($stream);
     }
 
-    private function streamFromString(string $s)
+    private function fileFromString(string $s)
     {
-        $stream = fopen('php://memory', 'rw');
-        fwrite($stream, $s);
-        rewind($stream);
-        return $stream;
+        $file = new \SplTempFileObject();
+        $file->fwrite($s);
+        $file->rewind();
+        return $file;
     }
 }


### PR DESCRIPTION
This is a start towards fixing #5.

It also introduces a `read()` method that can be used to get a defined number of bytes from the file. This method should not mutate the original file object, and will do its best to reset the file position to what it was prior to the read.

Currently it throws plain old bland `\Exception` instances when something goes wrong. Those should probably be turned into more specific ones. There are two different exceptions for two different failure states.

1. When any of its basic actions failed an exception gets thrown, these basic actions are:
   1. finding the current stream position in the file,
   2. moving to the position where the reading needs to start,
   3. reading bytes.
2. When the position could not be reset to where it was prior to the reading.

Now that I have written this out, I see I should have probably moved 1.i. to be under 2. The split into two exceptions if because the first is unrecoverable (the reading itself has failed) while the second might be recoverable (reading was fine, but has mutated the file object).

There is also a question related to reading that will need to be answered: what happens if the file contains less than 8 bytes?

Is it fine to return just the first however many bytes that were found? That – I believe – is the default behaviour of `fread()` (reading ’til EOF). Or should an exception been thrown from `read()` when you request 8 bytes and only 6 were found?

Let me know what you think, and lets iterate on the exceptions!