### PR TITLE
Coverage completionist: 97.67%

### DIFF
--- a/src/Detector.php
+++ b/src/Detector.php
@@ -141,6 +141,7 @@ final class Detector
     private function take(string $bstr, int $len): array
     {
         $out = [];
+        $len = min($len, strlen($bstr));
         for ($i = 0; $i < $len; $i++) {
             $out[] = ord($bstr[$i]);
         }

--- a/tests/DimensionsTest.php
+++ b/tests/DimensionsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use \Ancarda\File\Detector;
+use \PHPUnit\Framework\TestCase;
+
+final class DimensionsTest extends TestCase
+{
+    private $detector;
+
+    public function setUp()
+    {
+        $this->detector = new \Ancarda\File\Detector;
+    }
+
+    public function testSquarePNG()
+    {
+        $file = new \SplFileObject(__DIR__ . '/files/sample.png', 'r');
+
+        $this->assertSame([16, 16], $this->detector->determineDimensions($file));
+    }
+
+    public function testRectangleJPG()
+    {
+        $file = new \SplFileObject(__DIR__ . '/files/sample2.jpg', 'r');
+
+        $this->assertSame([3, 7], $this->detector->determineDimensions($file));
+    }
+
+    public function testNonImage()
+    {
+        $file = new \SplFileObject(__DIR__ . '/files/sample.xml', 'r');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->detector->determineDimensions($file);
+    }
+
+    public function testFromNonZeroCursorPosition()
+    {
+        $file = new \SplFileObject(__DIR__ . '/files/sample.jpg', 'r');
+        $file->fread(512);
+
+        $this->assertEquals([16, 16], $this->detector->determineDimensions($file));
+    }
+}

--- a/tests/MimeTest.php
+++ b/tests/MimeTest.php
@@ -56,6 +56,8 @@ final class MimeTest extends TestCase
 
     public function testEmptyFile()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Could not read specified bytes from the file.');
         $this->detector->determineMimeType(new \SplTempFileObject());
     }
 

--- a/tests/MimeTest.php
+++ b/tests/MimeTest.php
@@ -49,37 +49,6 @@ final class MimeTest extends TestCase
         $this->assertFileHasMimeType('sample.webp', 'image/webp');
     }
 
-    public function testDetermineDimensions()
-    {
-        $file = new \SplFileObject(__DIR__ . '/files/sample.png', 'r');
-
-        $this->assertSame([16, 16], $this->detector->determineDimensions($file));
-    }
-
-    public function testDetermineDimensionsWithRectangleImage()
-    {
-        $file = new \SplFileObject(__DIR__ . '/files/sample2.jpg', 'r');
-
-        $this->assertSame([3, 7], $this->detector->determineDimensions($file));
-    }
-
-    public function testDetermineDimensionsWithInvalidFileType()
-    {
-        $file = new \SplFileObject(__DIR__ . '/files/sample.xml', 'r');
-
-        $this->expectException(\InvalidArgumentException::class);
-
-        $this->detector->determineDimensions($file);
-    }
-
-    public function testDetermineDimensionsWithNonZeroPosition()
-    {
-        $file = new \SplFileObject(__DIR__ . '/files/sample.jpg', 'r');
-        $file->fread(512);
-
-        $this->assertEquals([16, 16], $this->detector->determineDimensions($file));
-    }
-
     public function testFlac()
     {
         $this->assertFileHasMimeType('sample.flac', 'audio/flac');


### PR DESCRIPTION
This makes a start at getting the library some more comprehensive tests.

I can’t get `getimagesizefromstring()` to return `false` without also throwing a PHP Error and halting execution. So it never gets in there. Not sure how to best handle it… there are some tests marked as incomplete that show this issue and might need more eyes on it.

When copying some of these extra dimensions tests over to the MIME tests I ran into a break when an empty file was given. This was fixed by making `take()` not read non-existing bytes.

There are probably even more tests that could be made for some of the if-statements but tis should do for a while.